### PR TITLE
Dilicom v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Dilicom Hub API: https://hub-dilicom.centprod.com/documentation/
 ```php
 # Very simple!
 $client = new Dilicom\RestClient("MY_GLN", "MY_PASSWORD", Dilicom\RestClient::ENV_PROD);
-echo $client->getOnixNotice("9782756406053");
+echo $client->getOnixNotice("9782756406053", "GLN_CONTRACTOR", "GLN_DISTRIBUTOR");
 ```
 
 Output:
@@ -77,7 +77,7 @@ require 'vendor/autoload.php';
 
 ## Available APIs
 
-* onix/getNotice?ean13=<ean13>&glnDistributor=<gln>: Get an ONIX notice for a given EAN13
+* onix/getNotice?ean13=<ean13>&glnDistributor=<gln>&glnDistributor=<gln>: Get an ONIX notice for a given EAN13
 
 ## You want to contribute?
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The recommended way to install php-dilicom is through [Composer](http://getcompo
 curl -sS https://getcomposer.org/installer | php
 
 # Add php-dilicom as a dependency
-php composer.phar require pkoin/php-dilicom:dev-master
+php composer.phar require pkoin/php-dilicom
 ```
 
 After installing, you need to require Composer's autoloader:

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "guzzle/guzzle": ">=3"
     },
     "require-dev": {
-        "atoum/atoum": "dev-master"
+        "atoum/atoum": "dev-master",
+        "atoum/stubs": "~2.1"
     },
     "authors": [
         {

--- a/src/Dilicom/RestClient.php
+++ b/src/Dilicom/RestClient.php
@@ -103,16 +103,19 @@ class RestClient
      *
      * @param  string $ean13
      * @param  string $glnDistributor
-     * @param  string $unitPrice
+     * @param  int    $unitPrice
+     * @param  int    $unitPriceExcludingTax
+     *
      * @return string
      */
-    public function getEbookAvailability($ean13, $glnDistributor, $unitPrice)
+    public function getEbookAvailability($ean13, $glnDistributor, $unitPrice, $unitPriceExcludingTax)
     {
         return $this->getEbooksAvailabilities(array(
             array(
                 "ean13" => $ean13,
                 "glnDistributor" => $glnDistributor,
-                "unitPrice" => $unitPrice
+                "unitPrice" => $unitPrice,
+                "unitPriceExcludingTax" => $unitPriceExcludingTax,
             )
         ));
     }
@@ -125,8 +128,8 @@ class RestClient
      */
     protected function checkEbookData(array $ebook)
     {
-        if (!isset($ebook["ean13"], $ebook["glnDistributor"], $ebook["unitPrice"])) {
-            throw new \InvalidArgumentException("Given ebook is badly formed. Expected something like array('ean13' => 'xxx', 'glnDistributor' => 'xxx', 'unitPrice' => 'x'), got : " . serialize($ebook));
+        if (!isset($ebook["ean13"], $ebook["glnDistributor"], $ebook["unitPrice"], $ebook["unitPriceExcludingTax"])) {
+            throw new \InvalidArgumentException("Given ebook is badly formed. Expected something like array('ean13' => 'xxx', 'glnDistributor' => 'xxx', 'unitPrice' => 'x', 'unitPriceExcludingTax' => 'x'), got : " . serialize($ebook));
         }
     }
 
@@ -148,6 +151,7 @@ class RestClient
             $query["checkAvailabilityLines[$i].ean13"] = $ebook["ean13"];
             $query["checkAvailabilityLines[$i].glnDistributor"] = $ebook["glnDistributor"];
             $query["checkAvailabilityLines[$i].unitPrice"] = $ebook["unitPrice"];
+            $query["checkAvailabilityLines[$i].unitPriceExcludingTax"] = $ebook["unitPriceExcludingTax"];
         }
 
         return $this->request("json/checkAvailability", array(

--- a/src/Dilicom/RestClient.php
+++ b/src/Dilicom/RestClient.php
@@ -191,10 +191,11 @@ class RestClient
      */
     protected function request($api, $options=array())
     {
-        return $this->connector->get("/v1/hub-numerique-api/$api", null, array_merge(array(
+        return $this->connector->get("/v3/hub-numerique-api/$api", null, array_merge(array(
             "auth"      => array($this->user, $this->password),
             "verify"    => $this->should_verify_ssl,
             "debug"     => $this->enable_debug
         ), $options));
     }
+
 }

--- a/src/Dilicom/RestClient.php
+++ b/src/Dilicom/RestClient.php
@@ -35,6 +35,12 @@ class RestClient
     protected $password;
 
     /**
+     * Reseller's country, ISO 3166-1
+     * @var string
+     */
+    protected $resellerCountry;
+
+    /**
      * Should the ssl certificate be checked?
      * @var boolean
      */
@@ -132,6 +138,11 @@ class RestClient
     public function getEbooksAvailabilities($ebooks)
     {
         $query = array();
+
+        if (!empty($this->resellerCountry)) {
+            $query['country'] = $this->resellerCountry;
+        }
+
         foreach ($ebooks as $i => $ebook) {
             $this->checkEbookData($ebook);
             $query["checkAvailabilityLines[$i].ean13"] = $ebook["ean13"];
@@ -179,6 +190,17 @@ class RestClient
     public function setConnector(ConnectorInterface $connector)
     {
         $this->connector = $connector;
+        return $this;
+    }
+
+    /**
+     * @param string $resellerCountry
+     *
+     * @return $this
+     */
+    public function setResellerCountry($resellerCountry)
+    {
+        $this->resellerCountry = $resellerCountry;
         return $this;
     }
 

--- a/src/Dilicom/RestClient.php
+++ b/src/Dilicom/RestClient.php
@@ -88,13 +88,20 @@ class RestClient
     /**
      * Get the ONIX notice for a given EAN13
      *
-     * @param  string $ean13
+     * @param string $ean13
+     * @param string $glnContractor
+     * @param string $glnDistributor
+     *
      * @return string
      */
-    public function getOnixNotice($ean13)
+    public function getOnixNotice($ean13, $glnContractor, $glnDistributor)
     {
         return $this->request("onix/getNotice", array(
-            "query" => array("ean13" => $ean13),
+            "query" => array(
+                "glnContractor" => $glnContractor,
+                "ean13" => $ean13,
+                "glnDistributor" => $glnDistributor,
+            ),
         ));
     }
 

--- a/tests/unit/Dilicom/RestClient.php
+++ b/tests/unit/Dilicom/RestClient.php
@@ -59,8 +59,8 @@ class RestClient extends atoum\test
         $this->calling($this->http_connector_mock)->get = $response;
 
         $availability = $this->tested_client->getEbooksAvailabilities(array(
-            array("ean13" => "9780000000000", "glnDistributor" => "3330000000000", "unitPrice" => 0),
-            array("ean13" => "9770000000000", "glnDistributor" => "3230000000000", "unitPrice" => 5),
+            array("ean13" => "9780000000000", "glnDistributor" => "3330000000000", "unitPrice" => 0, "unitPriceExcludingTax" => 0),
+            array("ean13" => "9770000000000", "glnDistributor" => "3230000000000", "unitPrice" => 5, "unitPriceExcludingTax" => 4),
         ));
 
         $this->mock($this->http_connector_mock)
@@ -76,9 +76,11 @@ class RestClient extends atoum\test
                         "checkAvailabilityLines[0].ean13" => "9780000000000",
                         "checkAvailabilityLines[0].glnDistributor" => "3330000000000",
                         "checkAvailabilityLines[0].unitPrice" => "0",
+                        "checkAvailabilityLines[0].unitPriceExcludingTax" => "0",
                         "checkAvailabilityLines[1].ean13" => "9770000000000",
                         "checkAvailabilityLines[1].glnDistributor" => "3230000000000",
                         "checkAvailabilityLines[1].unitPrice" => "5",
+                        "checkAvailabilityLines[1].unitPriceExcludingTax" => "4",
                     )
                 )
              )
@@ -96,7 +98,7 @@ class RestClient extends atoum\test
         $response = "Availability response";
         $this->calling($this->http_connector_mock)->get = $response;
 
-        $availability = $this->tested_client->getEbookAvailability("9780000000000", "3330000000000", 749);
+        $availability = $this->tested_client->getEbookAvailability("9780000000000", "3330000000000", 749, 600);
 
         $this
             ->string($availability)

--- a/tests/unit/Dilicom/RestClient.php
+++ b/tests/unit/Dilicom/RestClient.php
@@ -113,7 +113,7 @@ class RestClient extends atoum\test
         $this->calling($this->http_connector_mock)->get = $response;
 
         $this
-            ->string($this->tested_client->getOnixNotice("9780000000000"))
+            ->string($this->tested_client->getOnixNotice("9780000000000", "gln123", "gln456"))
                 ->isEqualTo($response)
         ;
     }

--- a/tests/unit/Dilicom/RestClient.php
+++ b/tests/unit/Dilicom/RestClient.php
@@ -66,7 +66,7 @@ class RestClient extends atoum\test
         $this->mock($this->http_connector_mock)
              ->call("get")
              ->withArguments(
-                "/v1/hub-numerique-api/json/checkAvailability",
+                "/v3/hub-numerique-api/json/checkAvailability",
                 null,
                 array(
                     "auth" => array("user", "password"),


### PR DESCRIPTION
Dilicom a lancé son API v3 il y a quelques temps => il faut l'utiliser.
Cette API v3 ajoute des paramètres obligatoires (ou à moitié obligatoires) sur les différents appels supportés par ce composant => ajout des paramètres ici.

Ça casse complétement la compatibilité antérieure => j'ai créé un tag 1.0.0 avant de faire ce dev ; et on basculera sur du 2.\* quand cette PR sera mergée (en espérant que personne ne soit sur `dev-master`).

Ping @oservieres et @astranchet 
